### PR TITLE
enh: changed git_url parsing and added name editing when cloning with git

### DIFF
--- a/modelhub_app/main_app.py
+++ b/modelhub_app/main_app.py
@@ -1,12 +1,13 @@
 # modelhub_app/main_app.py
 import gradio as gr
 from modelhub_core.modelhub_logic import ModelHubLogic
+import os
 
 # Crear instancia con valores por defecto
 hub = ModelHubLogic()
 
-def ui_clone_model(git_url):
-    return hub.clone_model(git_url)
+def ui_clone_model(git_url, model_name):
+    return hub.clone_model(git_url, name=model_name)
 
 def ui_copy_local_model(local_path, model_name):
     return hub.copy_local_model(local_path, model_name)
@@ -18,11 +19,17 @@ with gr.Blocks() as demo:
     gr.Markdown("# Model Hub")
     
     with gr.Tab("Clonar desde Git"):
-        git_url_input = gr.Textbox(label="URL de repositorio Git")
+        git_url_input = gr.Textbox(label="URL de repositorio Git", value="https://hub/repo.git")
+        git_name_input = gr.Textbox(label="Nombre del modelo (opcional)")
+        
+        def update_model_name(git_url):
+            return os.path.basename(git_url).replace(".git", "")
+        
+        git_url_input.change(fn=update_model_name, inputs=[git_url_input], outputs=[git_name_input])
         clone_button = gr.Button("Descargar modelo")
         clone_output = gr.Textbox(label="Resultado", lines=3)
 
-        clone_button.click(ui_clone_model, inputs=[git_url_input], outputs=[clone_output])
+        clone_button.click(ui_clone_model, inputs=[git_url_input, git_name_input], outputs=[clone_output])
 
     with gr.Tab("Copiar modelo local"):
         local_path_input = gr.Textbox(label="Ruta local del modelo (directorio)")
@@ -39,4 +46,4 @@ with gr.Blocks() as demo:
         list_output = gr.Textbox(label="Modelos", lines=10)
         list_button.click(ui_list_models, outputs=[list_output])
 
-demo.launch(share=True, server_name="0.0.0.0", server_port=7860)
+demo.launch(share=False, server_name="0.0.0.0", server_port=7860)

--- a/modelhub_core/modelhub_logic.py
+++ b/modelhub_core/modelhub_logic.py
@@ -12,10 +12,13 @@ class ModelHubLogic:
         # Asegúrate de inicializar la BD si no existe
         self.db.init_db()
 
-    def clone_model(self, git_url):
+    def clone_model(self, git_url, name=None):
         """Clona un repo Git en el directorio compartido y registra en BD."""
         # 1. Extraer nombre del repo
-        name = os.path.splitext(os.path.basename(git_url))[0]
+        if not name:
+            name = os.path.basename(git_url).replace(".git", "")
+        if not name:
+            return "Error: No se pudo determinar un nombre de modelo válido."
 
         # 2. Comprobar si existe ya
         if self.db.model_exists(name=name, url=git_url):


### PR DESCRIPTION
Fixes #3 

Copilot summary:

This pull request introduces several enhancements to the `modelhub_app` and `modelhub_core` modules, mainly focusing on improving the user interface for cloning models and refining the model cloning logic.

### User Interface Enhancements:
* [`modelhub_app/main_app.py`](diffhunk://#diff-2bc0c93b6d67441be2c8636574b2d759ca688e9778e5860a550a1dc7fb2e32d0R4-R10): Added a new input field for the model name in the "Clonar desde Git" tab and updated the `ui_clone_model` function to accept the model name as a parameter. [[1]](diffhunk://#diff-2bc0c93b6d67441be2c8636574b2d759ca688e9778e5860a550a1dc7fb2e32d0R4-R10) [[2]](diffhunk://#diff-2bc0c93b6d67441be2c8636574b2d759ca688e9778e5860a550a1dc7fb2e32d0L21-R32)
* [`modelhub_app/main_app.py`](diffhunk://#diff-2bc0c93b6d67441be2c8636574b2d759ca688e9778e5860a550a1dc7fb2e32d0L21-R32): Implemented a function to automatically update the model name based on the Git URL entered by the user.

### Logic Improvements:
* [`modelhub_core/modelhub_logic.py`](diffhunk://#diff-c6728d6ffe1c0d349c3561556b1ff90606852e4930e85f49d9010ab53f9805feL15-R21): Modified the `clone_model` function to accept an optional `name` parameter and handle cases where the name cannot be determined from the Git URL.

### Miscellaneous:
* [`modelhub_app/main_app.py`](diffhunk://#diff-2bc0c93b6d67441be2c8636574b2d759ca688e9778e5860a550a1dc7fb2e32d0L42-R49): Changed the `demo.launch` configuration to disable sharing by default.