### PR TITLE
feat: add model deletion (back) and database refresh functionality

### DIFF
--- a/modelhub_app/main_app.py
+++ b/modelhub_app/main_app.py
@@ -13,7 +13,9 @@ def ui_copy_local_model(local_path, model_name):
     return hub.copy_local_model(local_path, model_name)
 
 def ui_list_models():
-    return hub.list_models()
+    changes = hub.refresh_db()
+    models_list = hub.list_models()
+    return changes, models_list
 
 with gr.Blocks() as demo:
     gr.Markdown("# Model Hub")
@@ -44,6 +46,8 @@ with gr.Blocks() as demo:
     with gr.Tab("Listar modelos"):
         list_button = gr.Button("Refrescar lista")
         list_output = gr.Textbox(label="Modelos", lines=10)
-        list_button.click(ui_list_models, outputs=[list_output])
+        refresh_info = gr.Textbox(label="Cambios", lines=3)
+
+        list_button.click(ui_list_models, outputs=[refresh_info, list_output])
 
 demo.launch(share=False, server_name="0.0.0.0", server_port=7860)

--- a/modelhub_core/db_manager.py
+++ b/modelhub_core/db_manager.py
@@ -37,6 +37,14 @@ class DBManager:
         conn.commit()
         conn.close()
 
+    def delete_model(self, name):
+        """Elimina un modelo de la BD por nombre."""
+        conn = sqlite3.connect(self.db_path)
+        c = conn.cursor()
+        c.execute("DELETE FROM models WHERE name=?", (name,))
+        conn.commit()
+        conn.close()
+
     def model_exists(self, name=None, url=None):
         """Comprueba si existe un modelo, por nombre o url."""
         conn = sqlite3.connect(self.db_path)


### PR DESCRIPTION
Fixes #2 

Copilot summary:
This pull request introduces several changes to the `modelhub_app` and `modelhub_core` modules to enhance model management functionality, specifically by adding the ability to refresh the database and delete models. Key changes include updating the UI to display changes when refreshing the model list and adding methods to manage the database.

Enhancements to model management:

* [`modelhub_core/db_manager.py`](diffhunk://#diff-ad4fb013ab6b1c8dc370ddf77c0408e71a188b7cf9a0349d7313a08b5a8eec50R40-R47): Added a new method `delete_model` to remove a model from the database by name.
* [`modelhub_core/modelhub_logic.py`](diffhunk://#diff-c6728d6ffe1c0d349c3561556b1ff90606852e4930e85f49d9010ab53f9805feR86-R110): Introduced a new method `refresh_db` to update the database based on the current state of the shared directory, including adding and removing models as necessary.

UI updates:

* [`modelhub_app/main_app.py`](diffhunk://#diff-2bc0c93b6d67441be2c8636574b2d759ca688e9778e5860a550a1dc7fb2e32d0L16-R18): Modified the `ui_list_models` function to return both the changes and the list of models, and updated the UI to display these changes. [[1]](diffhunk://#diff-2bc0c93b6d67441be2c8636574b2d759ca688e9778e5860a550a1dc7fb2e32d0L16-R18) [[2]](diffhunk://#diff-2bc0c93b6d67441be2c8636574b2d759ca688e9778e5860a550a1dc7fb2e32d0L47-R51)